### PR TITLE
[db]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.db?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # db
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# db
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: '/bin/db_dump'

--- a/controls/db_exists.rb
+++ b/controls/db_exists.rb
@@ -7,7 +7,8 @@ control 'core-plans-db-exists' do
   impact 1.0
   title 'Ensure db exists'
   desc '
-  '
+  Verify db by ensuring /bin/db_dump exists'
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/db_exists.rb
+++ b/controls/db_exists.rb
@@ -1,0 +1,22 @@
+title 'Tests to confirm db exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'db')
+ 
+control 'core-plans-db-exists' do
+  impact 1.0
+  title 'Ensure db exists'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: '/bin/db_dump')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/db_works.rb
+++ b/controls/db_works.rb
@@ -1,0 +1,25 @@
+title 'Tests to confirm db works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'db')
+
+control 'core-plans-db-works' do
+  impact 1.0
+  title 'Ensure db works as expected'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} db_dump -V") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /Berkeley DB #{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/db_works.rb
+++ b/controls/db_works.rb
@@ -7,7 +7,10 @@ control 'core-plans-db-works' do
   impact 1.0
   title 'Ensure db works as expected'
   desc '
+  Verify db by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: db
+title: Habitat Core Plan db
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan db
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/patches/atomic.patch
+++ b/patches/atomic.patch
@@ -1,0 +1,20 @@
+--- src/dbinc/atomic.h	2013-03-12 14:07:22.000000000 -0400
++++ src/dbinc/atomic.h.change	2013-03-12 14:06:35.000000000 -0400
+@@ -144,7 +144,7 @@
+ #define	atomic_inc(env, p)	__atomic_inc(p)
+ #define	atomic_dec(env, p)	__atomic_dec(p)
+ #define	atomic_compare_exchange(env, p, o, n)	\
+-	__atomic_compare_exchange((p), (o), (n))
++	__atomic_compare_exchange_db((p), (o), (n))
+ static inline int __atomic_inc(db_atomic_t *p)
+ {
+ 	int	temp;
+@@ -176,7 +176,7 @@
+  * http://gcc.gnu.org/onlinedocs/gcc-4.1.0/gcc/Atomic-Builtins.html
+  * which configure could be changed to use.
+  */
+-static inline int __atomic_compare_exchange(
++static inline int __atomic_compare_exchange_db(
+ 	db_atomic_t *p, atomic_value_t oldval, atomic_value_t newval)
+ {
+ 	atomic_value_t was;

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,71 @@
+pkg_name=db
+pkg_origin=core
+pkg_version=5.3.28
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+Berkeley DB is a family of embedded key-value database libraries providing \
+scalable high-performance data management services to applications.\
+"
+pkg_upstream_url="http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html"
+pkg_license=('custom')
+# Oracle's official download link for Berkeley DB is now behind a login screen
+# Pull from LFS mirrors for now
+pkg_source="https://download.oracle.com/berkeley-db/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="e0a992d740709892e81f9d93f06daf305cf73fb81b545afe72478043172c3628"
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_prepare() {
+  # Many thanks to Arch Linux
+  # https://git.archlinux.org/svntogit/packages.git/plain/trunk/atomic.patch?h=packages/db
+  patch -p0 < $PLAN_CONTEXT/patches/atomic.patch
+}
+
+do_build() {
+  pushd build_unix > /dev/null
+  ../dist/configure \
+    --prefix="${pkg_prefix}" \
+    --enable-compat185 \
+    --enable-cxx \
+    --enable-dbm \
+    --enable-stl
+  make LIBSO_LIBS=-lpthread -j"$(nproc)"
+  popd > /dev/null
+}
+
+do_install() {
+  pushd build_unix > /dev/null
+  do_default_install
+  make uninstall_docs
+  popd > /dev/null
+
+  # Install license file
+  install -Dm644 LICENSE "${pkg_prefix}/share/licenses/LICENSE"
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/coreutils
+  )
+fi


### PR DESCRIPTION
```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://512700fb95bf2a5297e75d34c4aed517ddfebb7a1dddbae1cfa0ddaede4cebc5 --input-file /src/attributes.yml

Profile: Habitat Core Plan db (db)
Version: 0.1.0
Target:  docker://512700fb95bf2a5297e75d34c4aed517ddfebb7a1dddbae1cfa0ddaede4cebc5

  ✔  core-plans-db-exists: Ensure db exists
     ✔  File /hab/pkgs/core/db/5.3.28/20200602234246/bin/db_dump is expected to exist
  ✔  core-plans-db-works: Ensure db works as expected
     ✔  Command: `hab pkg path core/db` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/db` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/db/5.3.28/20200602234246 db_dump -V` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/db/5.3.28/20200602234246 db_dump -V` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/db/5.3.28/20200602234246 db_dump -V` stdout is expected to match /Berkeley DB 5.3.28/
     ✔  Command: `DEBUG=true; hab pkg exec core/db/5.3.28/20200602234246 db_dump -V` stderr is expected to be empty


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
+ set +x
[15][default:/src:0]# 
```